### PR TITLE
[0.1.2] Add support for dynamic nalgebra matrix/vectors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cSpell.enabled": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "cSpell.enabled": false
-}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eqsolver"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "A library that solves equations using numerical methods"
 repository = "https://github.com/AzeezDa/eqsolver"
@@ -16,8 +16,6 @@ maintenance = { status = "passively-maintained" }
 name = "eqsolver"
 path = "src/lib.rs"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-nalgebra = "0.31.0"
+nalgebra = "0.32.2"
 num-traits = "0.2.15"

--- a/src/solvers/gaussnewton_fd.rs
+++ b/src/solvers/gaussnewton_fd.rs
@@ -1,35 +1,58 @@
+use std::marker::PhantomData;
+
+use super::{SolverError, VectorType, DEFAULT_ITERMAX, DEFAULT_TOL};
 #[allow(dead_code)]
 use nalgebra::ComplexField;
-use nalgebra::{SMatrix, SVector};
+use nalgebra::{allocator::Allocator, Const, DefaultAllocator, Dim};
 use num_traits::{Float, Signed};
-use super::{SolverError, DEFAULT_ITERMAX, DEFAULT_TOL};
 
-/// # Gauss-Newton with Finite Differences 
-/// 
+/// # Gauss-Newton with Finite Differences
+///
 /// Solves x in a system of equation F(x) = 0 (where F: Rm ⟶ Rn) by minimizing ||F(x)|| in a Least Square Sense using The Gauss-Newton algorithm ([Wikipedia](https://en.wikipedia.org/wiki/Gauss%E2%80%93Newton_algorithm)). This struct uses a closure that takes a nalgebra vector (size m) and outputs a nalgebra vector (size n) to represent the overdetermined system of equations. The struct approximates the Jacobian using finite differences.
-/// 
+///
 /// **Default Tolerance:** 1e-6
-/// 
+///
 /// **Default Max Iterations:** 50
-pub struct GaussNewtonFD<T, F, const R: usize, const C: usize>
+pub struct GaussNewtonFD<T, R, C, F>
 where
-    T: Float + ComplexField + Signed,
-    F: Fn(SVector<T, R>) -> SVector<T, C>,
+    T: Float + ComplexField<RealField = T> + Signed,
+    R: Dim,
+    C: Dim,
+    F: Fn(VectorType<T, C>) -> VectorType<T, R>,
+    DefaultAllocator: Allocator<T, C, R>
+        + Allocator<T, C>
+        + Allocator<T, R>
+        + Allocator<T, Const<1>, R>
+        + Allocator<T, C, Const<1>>
+        + Allocator<T, Const<1>, C>
+        + Allocator<T, R, C>
+        + Allocator<T, C, C>
 {
     f: F,
     h: T,
     tolerance: T,
     iter_max: usize,
+    r_phantom: PhantomData<R>,
+    c_phantom: PhantomData<C>,
 }
 
-impl<T, F, const R: usize, const C: usize> GaussNewtonFD<T, F, R, C>
+impl<T, R, C, F> GaussNewtonFD<T, R, C, F>
 where
-    T: Float + ComplexField + Signed,
-    F: Fn(SVector<T, R>) -> SVector<T, C>,
+    T: Float + ComplexField<RealField = T> + Signed,
+    R: Dim,
+    C: Dim,
+    F: Fn(VectorType<T, C>) -> VectorType<T, R>,
+    DefaultAllocator: Allocator<T, C, R>
+        + Allocator<T, C>
+        + Allocator<T, R>
+        + Allocator<T, Const<1>, R>
+        + Allocator<T, C, Const<1>>
+        + Allocator<T, Const<1>, C>
+        + Allocator<T, R, C>
+        + Allocator<T, C, C>
 {
-
     /// Create a new instance of the algorithm
-    /// 
+    ///
     /// Instantiates the Gauss-Newton algorithm using the system of equation F and its Jacobian J.
     pub fn new(f: F) -> Self {
         Self {
@@ -37,11 +60,13 @@ where
             h: Float::sqrt(T::epsilon()),
             tolerance: T::from(DEFAULT_TOL).unwrap(),
             iter_max: DEFAULT_ITERMAX,
+            r_phantom: PhantomData,
+            c_phantom: PhantomData,
         }
     }
 
     /// Updates the solver's tolerance (Magnitude of Error).
-    /// 
+    ///
     /// **Default Tolerance:** 1e-6
     pub fn with_tol(&mut self, tol: T) -> &mut Self {
         self.tolerance = tol;
@@ -49,7 +74,7 @@ where
     }
 
     /// Updates the solver's amount of iterations done before terminating the iteration
-    /// 
+    ///
     /// **Default Max Iterations:** 50
     pub fn with_itermax(&mut self, max: usize) -> &mut Self {
         self.iter_max = max;
@@ -57,7 +82,7 @@ where
     }
 
     /// Updates the step length used in the finite difference
-    /// 
+    ///
     /// **Default Step length for Finite Difference:** √(Machine Epsilon)
     pub fn with_fd_step_length(&mut self, h: T) -> &mut Self {
         self.h = h;
@@ -65,31 +90,33 @@ where
     }
 
     /// Run the algorithm
-    /// 
+    ///
     /// Finds x such that ||F(x)|| is minimized where F is the overdetermined system of equations.
-    pub fn solve(&self, mut x0: SVector<T, R>) -> Result<SVector<T, R>, SolverError> {
-        let mut dv: SVector<T, R> = SVector::repeat(T::max_value()); // We assume error vector is infinitely long at the start
+    pub fn solve(&self, mut x0: VectorType<T, C>) -> Result<VectorType<T, C>, SolverError> {
+        let mut dv = x0.clone().add_scalar(T::max_value()); // We assume error vector is infinitely long at the start
         let mut iter = 1;
+        let fx = (self.f)(x0.clone());
+        let zero = (fx * x0.clone().transpose()).scale(T::zero());
 
         while dv.abs().max() > self.tolerance && iter < self.iter_max {
-            let mut j: SMatrix<T, C, R> = SMatrix::zeros(); // Jacobian, will be approximated below
-            let fx = (self.f)(x0);
+            let mut j = zero.clone(); // Jacobian, will be approximated below
+            let fx = (self.f)(x0.clone());
 
             // Approximate Jacobi using forward finite difference
-            for i in 0..R {
-                let mut x_h = x0;
+            for i in 0..j.ncols() {
+                let mut x_h = x0.clone();
                 x_h[i] = x_h[i] + self.h; // Add derivative step to specific parameter
-                let df = ((self.f)(x_h) - fx)/self.h; // Derivative of F with respect to x_i
-                for k in 0..C {
+                let df = ((self.f)(x_h) - fx.clone()) / self.h; // Derivative of F with respect to x_i
+                for k in 0..j.nrows() {
                     j[(k, i)] = df[k];
                 }
             }
 
             // Gauss Newton Iteration
             let jt = j.transpose();
-            if let Some(jjt_inv) = (jt*j).try_inverse() {
-                dv = jjt_inv*jt*fx;
-                x0 = x0 - dv;
+            if let Some(jjt_inv) = (jt.clone() * j).try_inverse() {
+                dv = jjt_inv * jt * fx;
+                x0 = x0 - dv.clone();
                 iter += 1;
             } else {
                 return Err(SolverError::BadJacobian);

--- a/src/solvers/mod.rs
+++ b/src/solvers/mod.rs
@@ -1,3 +1,5 @@
+use nalgebra::{Vector, Matrix, DefaultAllocator, allocator::Allocator};
+
 mod secant;
 mod newton;
 mod fdnewton;
@@ -71,4 +73,7 @@ pub enum ODESolverMethod {
     RungeKutta4
 }
 
-type SolverResult<T> = Result<T, SolverError>;
+pub type SolverResult<T> = Result<T, SolverError>;
+
+type VectorType<T, D> = Vector<T, D, <DefaultAllocator as Allocator<T, D>>::Buffer>;
+type MatrixType<T, D> = Matrix<T, D, D, <DefaultAllocator as Allocator<T, D, D>>::Buffer>;

--- a/src/solvers/mod.rs
+++ b/src/solvers/mod.rs
@@ -76,4 +76,4 @@ pub enum ODESolverMethod {
 pub type SolverResult<T> = Result<T, SolverError>;
 
 type VectorType<T, D> = Vector<T, D, <DefaultAllocator as Allocator<T, D>>::Buffer>;
-type MatrixType<T, D> = Matrix<T, D, D, <DefaultAllocator as Allocator<T, D, D>>::Buffer>;
+type MatrixType<T, R, C> = Matrix<T, R, C, <DefaultAllocator as Allocator<T, R, C>>::Buffer>;

--- a/src/solvers/multinewton.rs
+++ b/src/solvers/multinewton.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use nalgebra::{allocator::Allocator, ComplexField, DefaultAllocator, Dim, Scalar, DimName};
+use nalgebra::{allocator::Allocator, ComplexField, DefaultAllocator, Dim, Scalar};
 use num_traits::{Float, Signed};
 
 use super::{MatrixType, SolverError, VectorType, DEFAULT_ITERMAX, DEFAULT_TOL};
@@ -38,8 +38,8 @@ use super::{MatrixType, SolverError, VectorType, DEFAULT_ITERMAX, DEFAULT_TOL};
 pub struct MultiVarNewton<T, D, F, J>
 where
     T: Float + Scalar + ComplexField + Signed,
-    D: Dim + DimName,
-    J: Fn(VectorType<T, D>) -> MatrixType<T, D>,
+    D: Dim,
+    J: Fn(VectorType<T, D>) -> MatrixType<T, D, D>,
     F: Fn(VectorType<T, D>) -> VectorType<T, D>,
     DefaultAllocator: Allocator<T, D, D> + Allocator<T, D>,
 {
@@ -52,9 +52,9 @@ where
 
 impl<T, D, F, J> MultiVarNewton<T, D, F, J>
 where
-    T: Float + Scalar + ComplexField + Signed,
-    D: Dim + DimName,
-    J: Fn(VectorType<T, D>) -> MatrixType<T, D>,
+    T: Float + Scalar + ComplexField<RealField = T> + Signed,
+    D: Dim,
+    J: Fn(VectorType<T, D>) -> MatrixType<T, D, D>,
     F: Fn(VectorType<T, D>) -> VectorType<T, D>,
     DefaultAllocator: Allocator<T, D, D> + Allocator<T, D>,
 {
@@ -171,7 +171,7 @@ where
     /// assert_eq!(solution.err().unwrap(), SolverError::BadJacobian);
     /// ```
     pub fn solve(&self, mut x0: VectorType<T, D>) -> Result<VectorType<T, D>, SolverError> {
-        let mut dv = VectorType::<T,D>::repeat(T::max_value()); // We assume error vector is infinitely long at the start
+        let mut dv = x0.clone().add_scalar(T::max_value()); // We assume error vector is infinitely long at the start
         let mut iter = 1;
 
         // Newton-Raphson Iteration

--- a/src/solvers/multinewton_fd.rs
+++ b/src/solvers/multinewton_fd.rs
@@ -1,15 +1,17 @@
+use std::marker::PhantomData;
+
+use super::{MatrixType, SolverError, VectorType, DEFAULT_ITERMAX, DEFAULT_TOL};
 #[allow(dead_code)]
 use nalgebra::ComplexField;
-use nalgebra::{SMatrix, SVector};
+use nalgebra::{allocator::Allocator, DefaultAllocator, Dim, DimName};
 use num_traits::{Float, Signed};
-use super::{SolverError, DEFAULT_ITERMAX, DEFAULT_TOL};
 
 /// # Multivarite Newton-Raphson with Finite Differences
 /// 
 /// This struct finds x such that F(x) = 0 where F: Rn ⟶ Rn is a vectorial function. The vector x is given as a nalgebra vector and the solution will be of the same dimension as the input vector. This struct approximates the Jacobian using finite differences. This struct uses the Newton-Raphson method for system of equations ([Wikipedia](https://en.wikipedia.org/wiki/Newton%27s_method#k_variables,_k_functions)).
-/// 
+///
 /// **Default Tolerance:** 1e-6
-/// 
+///
 /// **Default Max Iterations:** 50
 /// 
 /// ## Examples
@@ -19,32 +21,37 @@ use super::{SolverError, DEFAULT_ITERMAX, DEFAULT_TOL};
 /// use nalgebra::{Vector2, Matrix2};
 /// // Vectorial Function (x, y) ↦ (x^2-y-1, xy - 2). Want to solve x^2 - y = 1 and xy = 2
 /// let F = |v: Vector2<f64>| Vector2::new(v[0].powi(2) - v[1] - 1., v[0] * v[1] - 2.);
-/// 
+///
 /// // Solved analytically but form was ugly so here is approximation
 /// const SOLUTION: Vector2<f64> = Vector2::new(1.521379706804567569604081, 1.314596212276751981650111);
-/// 
+///
 /// let solution = MultiVarNewtonFD::new(F)
 ///                 .with_tol(1e-6)
 ///                 .solve(Vector2::new(1., 1.))
 ///                 .unwrap();
-/// 
+///
 /// assert!((solution - SOLUTION).norm() <= 1e-6);
 /// ```
-pub struct MultiVarNewtonFD<T, F, const S: usize>
+pub struct MultiVarNewtonFD<T, D, F>
 where
     T: Float + ComplexField + Signed,
-    F: Fn(SVector<T, S>) -> SVector<T, S>,
+    D: Dim + DimName,
+    F: Fn(VectorType<T, D>) -> VectorType<T, D>,
+    DefaultAllocator: Allocator<T, D> + Allocator<T, D, D>,
 {
     f: F,
     h: T,
     tolerance: T,
     iter_max: usize,
+    d_phantom: PhantomData<D>,
 }
 
-impl<T, F, const S: usize> MultiVarNewtonFD<T, F, S>
+impl<T, D, F> MultiVarNewtonFD<T, D, F>
 where
     T: Float + ComplexField + Signed,
-    F: Fn(SVector<T, S>) -> SVector<T, S>,
+    D: Dim + DimName,
+    F: Fn(VectorType<T, D>) -> VectorType<T, D>,
+    DefaultAllocator: Allocator<T, D> + Allocator<T, D, D>,
 {
     /// Set up the solver
     /// 
@@ -56,7 +63,7 @@ where
     /// use nalgebra::{Vector2, Matrix2};
     /// // Vectorial Function (x, y) ↦ (x^2-y-1, xy - 2). Want to solve x^2 - y = 1 and xy = 2
     /// let F = |v: Vector2<f64>| Vector2::new(v[0].powi(2) - v[1] - 1., v[0] * v[1] - 2.);
-    /// 
+    ///
     /// let solution = MultiVarNewtonFD::new(F);
     /// ```
     pub fn new(f: F) -> Self {
@@ -65,11 +72,12 @@ where
             h: Float::sqrt(T::epsilon()),
             tolerance: T::from(DEFAULT_TOL).unwrap(),
             iter_max: DEFAULT_ITERMAX,
+            d_phantom: PhantomData
         }
     }
 
     /// Updates the solver's tolerance (Magnitude of Error).
-    /// 
+    ///
     /// **Default Tolerance:** 1e-6
     /// 
     /// ## Examples
@@ -78,15 +86,15 @@ where
     /// use nalgebra::{Vector2, Matrix2};
     /// // Vectorial Function (x, y) ↦ (x^2-y-1, xy - 2). Want to solve x^2 - y = 1 and xy = 2
     /// let F = |v: Vector2<f64>| Vector2::new(v[0].powi(2) - v[1] - 1., v[0] * v[1] - 2.);
-    /// 
+    ///
     /// // Solved analytically but form was ugly so here is approximation
     /// const SOLUTION: Vector2<f64> = Vector2::new(1.521379706804567569604081, 1.314596212276751981650111);
-    /// 
+    ///
     /// let solution = MultiVarNewtonFD::new(F)
     ///                 .with_tol(1e-12)
     ///                 .solve(Vector2::new(1., 1.))
     ///                 .unwrap();
-    /// 
+    ///
     /// assert!((solution - SOLUTION).norm() <= 1e-12);
     /// ```
     pub fn with_tol(&mut self, tol: T) -> &mut Self {
@@ -94,7 +102,7 @@ where
         self
     }
     /// Updates the solver's amount of iterations done before terminating the iteration
-    /// 
+    ///
     /// **Default Max Iterations:** 50
     pub fn with_itermax(&mut self, max: usize) -> &mut Self {
         self.iter_max = max;
@@ -102,7 +110,7 @@ where
     }
 
     /// Updates the step length used in the finite difference
-    /// 
+    ///
     /// **Default Step length for Finite Difference:** √(Machine Epsilon)
     /// 
     /// ## Examples
@@ -111,14 +119,14 @@ where
     /// # use nalgebra::{Vector2, Matrix2};
     /// // Vectorial Function (x, y) ↦ (x^2-y-1, xy - 2). Want to solve x^2 - y = 1 and xy = 2
     /// # let F = |v: Vector2<f64>| Vector2::new(v[0].powi(2) - v[1] - 1., v[0] * v[1] - 2.);
-    /// 
+    ///
     /// // Solved analytically but form was ugly so here is approximation
     /// # const SOLUTION: Vector2<f64> = Vector2::new(1.521379706804567569604081, 1.314596212276751981650111);
-    /// 
+    ///
     /// let solution = MultiVarNewtonFD::new(F)
     ///                 .with_fd_step_length(1e-3)
     ///                 .solve(Vector2::new(1., 1.));
-    /// 
+    ///
     /// # assert!((solution.unwrap() - SOLUTION).norm() <= 1e-6);
     pub fn with_fd_step_length(&mut self, h: T) -> &mut Self {
         self.h = h;
@@ -136,15 +144,15 @@ where
     /// use nalgebra::{Vector2, Matrix2};
     /// // Vectorial Function (x, y) ↦ (x^2-y-1, xy - 2). Want to solve x^2 - y = 1 and xy = 2
     /// let F = |v: Vector2<f64>| Vector2::new(v[0].powi(2) - v[1] - 1., v[0] * v[1] - 2.);
-    /// 
+    ///
     /// // Solved analytically but form was ugly so here is approximation
     /// const SOLUTION: Vector2<f64> = Vector2::new(1.521379706804567569604081, 1.314596212276751981650111);
-    /// 
+    ///
     /// let solution = MultiVarNewtonFD::new(F)
     ///                 .with_tol(1e-6)
     ///                 .solve(Vector2::new(1., 1.))
     ///                 .unwrap();
-    /// 
+    ///
     /// assert!((solution - SOLUTION).norm() <= 1e-6);
     /// ```
     /// 
@@ -155,28 +163,29 @@ where
     /// use nalgebra::{Vector2, Matrix2};
     /// // Vectorial Function (x, y) ↦ (x^2-y-1, xy - 2). Want to solve x^2 - y = 1 and xy = 2
     /// let F = |v: Vector2<f64>| Vector2::new(v[0] + v[1], v[0]*v[1]);
-    /// 
+    ///
     /// let solution = MultiVarNewtonFD::new(F)
     ///                 .with_tol(1e-6)
     ///                 .solve(Vector2::new(0., 0.)); // This will make the Jacobian very close to singular.  [1 1]
     ///                                                                                                    // [0 0]
-    /// 
+    ///
     /// assert_eq!(solution.err().unwrap(), SolverError::BadJacobian);
     /// ```
-    pub fn solve(&self, mut x0: SVector<T, S>) -> Result<SVector<T, S>, SolverError> {
-        let mut dv: SVector<T, S> = SVector::repeat(T::max_value()); // We assume error vector is infinitely long at the start
+    pub fn solve(&self, mut x0: VectorType<T, D>) -> Result<VectorType<T, D>, SolverError> {
+        let mut dv = VectorType::<T, D>::repeat(T::max_value()); // We assume error vector is infinitely long at the start
         let mut iter = 1;
+        let dim = x0.nrows();
 
         while dv.abs().max() > self.tolerance && iter < self.iter_max {
-            let mut j: SMatrix<T, S, S> = SMatrix::zeros(); // Jacobian, will be approximated below
-            let fx = (self.f)(x0);
+            let mut j: MatrixType<T, D> = MatrixType::<T, D>::zeros(); // Jacobian, will be approximated below
+            let fx = (self.f)(x0.clone());
 
             // Approximate Jacobi using forward finite difference
-            for i in 0..S {
-                let mut x_h = x0;
+            for i in 0..dim {
+                let mut x_h = x0.clone();
                 x_h[i] = x_h[i] + self.h; // Add derivative step to specific parameter
-                let df = ((self.f)(x_h) - fx)/self.h; // Derivative of F with respect to x_i
-                for k in 0..S {
+                let df = ((self.f)(x_h) - fx.clone()) / self.h; // Derivative of F with respect to x_i
+                for k in 0..dim {
                     j[(k, i)] = df[k];
                 }
             }
@@ -184,7 +193,7 @@ where
             // Newton-Raphson iteration
             if let Some(j_inv) = j.try_inverse() {
                 dv = j_inv * fx;
-                x0 = x0 - dv;
+                x0 = x0 - dv.clone();
                 iter += 1;
             } else {
                 return Err(SolverError::BadJacobian);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::finite_differences::{backward, central, forward};
 use crate::{multivariable::*, single_variable::*, ODESolver, SolverError};
-use nalgebra::{vector, Matrix2, Matrix3x2, Vector2, Vector3};
+use nalgebra::{vector, Matrix2, Matrix3x2, Vector2, Vector3, DVector, DMatrix};
 
 #[test]
 fn solve_secant() {
@@ -129,6 +129,83 @@ fn gauss_newton() {
     assert!((SOLUTION - solution_gn).norm() > 1e-12);
     assert!((SOLUTION - solution_gn_fd).norm() <= 1e-3);
     assert!((SOLUTION - solution_gn_fd).norm() > 1e-12);
+}
+
+
+#[test]
+fn dyn_multi_var_newton() {
+    // Vectorial Function (x, y) ↦ (x^2-y-1, xy - 2)
+    let f = |v: DVector<f64>| DVector::from_vec(vec![v[0].powi(2) - v[1] - 1., v[0] * v[1] - 2.]);
+
+    // Jacobian of F
+    let j = |v: DVector<f64>| DMatrix::from_vec(2, 2, vec![2. * v[0], v[1], -1., v[0]]);
+
+    // Solved analytically but form was ugly so here is approximation
+    const SOLUTION: Vector2<f64> =
+        Vector2::new(1.521379706804567569604081, 1.314596212276751981650111);
+
+    // Use struct generated above to solve the problem defined in f
+    let solution = MultiVarNewton::new(f, j)
+        .with_tol(1e-3)
+        .with_itermax(50)
+        .solve(DVector::repeat(2, 1.))
+        .unwrap();
+
+    // Use struct generated above to solve the problem defined in f
+    let solution_fd = MultiVarNewtonFD::new(f)
+        .with_tol(1e-3)
+        .with_itermax(50)
+        .solve(DVector::repeat(2, 1.))
+        .unwrap();
+
+    assert!((SOLUTION - &solution).norm() <= 1e-3);
+    assert!((SOLUTION - &solution).norm() > 1e-12);
+    assert!((SOLUTION - &solution_fd).norm() <= 1e-3);
+    assert!((SOLUTION - &solution_fd).norm() > 1e-12);
+}
+
+#[test]
+fn dyn_gauss_newton() {
+    // Test is about finding point closest to three circles in R2
+
+    // [Center_x, Center_y, Radius]
+    let c0 = [3., 5., 3.];
+    let c1 = [1., 0., 4.];
+    let c2 = [6., 2., 2.];
+
+    // Want to (x, y) such that F(x, y) = (x - X)^2 + (y - Y) - R^2 is minimized in a Least Square sense for data in c0, c1, c2
+    let f = |v: DVector<f64>| {
+        DVector::from_vec(vec![
+            (v[0] - c0[0]).powi(2) + (v[1] - c0[1]).powi(2) - c0[2] * c0[2],
+            (v[0] - c1[0]).powi(2) + (v[1] - c1[1]).powi(2) - c1[2] * c1[2],
+            (v[0] - c2[0]).powi(2) + (v[1] - c2[1]).powi(2) - c2[2] * c2[2],
+        ])
+    };
+
+    let j = |v: DVector<f64>| {
+        DMatrix::from_vec(3, 2, vec![
+            2. * (v[0] - c0[0]), 2. * (v[0] - c1[0]), 2. * (v[0] - c2[0]),
+            2. * (v[1] - c0[1]), 2. * (v[1] - c1[1]), 2. * (v[1] - c2[1]),
+        ])
+    };
+
+    // Solved using Octave (Can also be checked visually in Desmos or similar)
+    const SOLUTION: Vector2<f64> = vector![4.217265312839526, 2.317879970005811];
+
+    let solution_gn = GaussNewton::new(f, j)
+        .with_tol(1e-3)
+        .solve(DVector::from_vec(vec![4.5, 2.5]))
+        .unwrap();
+
+    let solution_gn_fd = GaussNewtonFD::new(f)
+        .with_tol(1e-3)
+        .solve(DVector::from_vec(vec![4.5, 2.5]))
+        .unwrap();
+
+    assert!((SOLUTION - &solution_gn).norm() <= 1e-3);
+    assert!((SOLUTION - &solution_gn).norm() > 1e-12);
+    assert!((SOLUTION - &solution_gn_fd).norm() <= 1e-3);
+    assert!((SOLUTION - &solution_gn_fd).norm() > 1e-12);
 }
 
 #[test]


### PR DESCRIPTION
DVector and DMatrix can now be used in the Gauss-Newton and Newton-Raphson (single and multivariate) solvers.