### PR TITLE
Make global optimisers a cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,15 @@ path = "src/lib.rs"
 [dependencies]
 nalgebra = "0.33.0"
 num-traits = "0.2.19"
-rand = "0.8.5"
-rand_distr = "0.4.3"
+rand = { version = "0.8.5", optional = true }
+rand_distr = { version = "0.4.3", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }
+
+[features]
+default = ["global_optimisers"]
+global_optimisers = ["dep:rand", "dep:rand_distr"]
 
 [[bench]]
 name = "eqsolver_benchmark"

--- a/src/solvers/mod.rs
+++ b/src/solvers/mod.rs
@@ -9,6 +9,7 @@ pub mod single_variable;
 /// Root-finders for equations of multiple variables
 pub mod multivariable;
 
+#[cfg(feature = "global_optimisers")]
 /// Finds global optimums of objective functions
 pub mod global_optimisers;
 


### PR DESCRIPTION
This PR hides the global optimisers module behind a feature flag, which is enabled by default.

Imo, this is the easiest way to fix #9 :)